### PR TITLE
Heuristic improvements

### DIFF
--- a/thoi/heuristics/commons.py
+++ b/thoi/heuristics/commons.py
@@ -1,0 +1,48 @@
+import torch
+
+
+def _get_valid_candidates(initial_solution: torch.Tensor, N: int, device: torch.device) -> torch.Tensor:
+    """
+    Efficiently generates valid candidates by excluding elements present in the initial solution.
+
+    Parameters:
+    - initial_solution (torch.Tensor): Tensor of shape (batch_size, o) containing selected indices. Note: o < N and all elements must be unique.
+    - N (int): Total number of possible elements.
+    - device (torch.device): Device where tensors are located.
+
+    Returns:
+    - valid_candidates (torch.Tensor): Tensor of shape (batch_size, N - o) containing valid candidate indices.
+    """
+
+    batch_size, o = initial_solution.shape
+
+    # Create a tensor of all elements, expanded across the batch
+    # |batch_size| x |N|
+    all_elements = torch.arange(N, device=device).unsqueeze(0).expand(batch_size, N)
+
+    # Expand initial_solution for comparison
+    # |batch_size| x |1| x |o|
+    initial_solution_expanded = initial_solution.unsqueeze(1)
+
+    # Expand all_elements for comparison
+    # |batch_size| x |N| x |1|
+    all_elements_expanded = all_elements.unsqueeze(2)
+
+    # Compare all_elements with initial_solution
+    # This creates a mask where True indicates the element is in initial_solution
+    # |batch_size| x |N| x |o|
+    is_in = (all_elements_expanded == initial_solution_expanded)
+
+    # Determine if any of the o elements match for each (batch, N)
+    # |batch_size| x |N|
+    is_in_any = is_in.any(dim=2)
+
+    # Create a mask for valid candidates (not in initial_solution)
+    # |batch_size| x |N|
+    valid_mask = ~is_in_any
+
+    # Select valid candidates using the mask
+    # |batch_size| x |N - o|
+    valid_candidates = torch.masked_select(all_elements, valid_mask).view(batch_size, N - o)
+
+    return valid_candidates

--- a/thoi/heuristics/greedy.py
+++ b/thoi/heuristics/greedy.py
@@ -68,6 +68,52 @@ def greedy(X: Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tenso
     
     return current_solution, torch.stack(best_scores).T
 
+def get_valid_candidates(initial_solution: torch.Tensor, N: int, device: torch.device) -> torch.Tensor:
+    """
+    Efficiently generates valid candidates by excluding elements present in the initial solution.
+
+    Parameters:
+    - initial_solution (torch.Tensor): Tensor of shape (batch_size, o) containing selected indices.
+    - N (int): Total number of possible elements.
+    - device (torch.device): Device where tensors are located.
+
+    Returns:
+    - valid_candidates (torch.Tensor): Tensor of shape (batch_size, N - o) containing valid candidate indices.
+    """
+    batch_size, o = initial_solution.shape
+
+    # Create a tensor of all elements, expanded across the batch
+    # |batch_size| x |N|
+    all_elements = torch.arange(N, device=device).unsqueeze(0).expand(batch_size, N)
+
+    # Expand initial_solution for comparison
+    # |batch_size| x |1| x |o|
+    initial_solution_expanded = initial_solution.unsqueeze(1)
+
+    # Expand all_elements for comparison
+    # |batch_size| x |N| x |1|
+    all_elements_expanded = all_elements.unsqueeze(2)
+
+    # Compare all_elements with initial_solution
+    # This creates a mask where True indicates the element is in initial_solution
+    # |batch_size| x |N| x |o|
+    is_in = (all_elements_expanded == initial_solution_expanded)
+
+    # Determine if any of the o elements match for each (batch, N)
+    # |batch_size| x |N|
+    is_in_any = is_in.any(dim=2)
+
+    # Create a mask for valid candidates (not in initial_solution)
+    # |batch_size| x |N|
+    valid_mask = ~is_in_any
+
+    # Select valid candidates using the mask
+    # |batch_size| x |N - o|
+    valid_candidates = torch.masked_select(all_elements, valid_mask).view(batch_size, N - o)
+
+    return valid_candidates
+
+
 def create_all_solutions(initial_solution: torch.Tensor, valid_solution: torch.Tensor) -> torch.Tensor:
     """
     Concatenates initial_solution with each valid_solution to create all_solutions.
@@ -79,18 +125,19 @@ def create_all_solutions(initial_solution: torch.Tensor, valid_solution: torch.T
     Returns:
     - all_solutions (torch.Tensor): Tensor of shape (batch_size, T, O + 1)
     """
-    batch_size, O = initial_solution.shape
-    _, T = valid_solution.shape
+    T = valid_solution.shape[1]
 
-    # Step 1: Expand initial_solution to (batch_size, T, O)
-    # unsqueeze to add a new dimension at position 1 (for T)
-    initial_expanded = initial_solution.unsqueeze(1).expand(-1, T, -1)  # Shape: (batch_size, T, O)
+    # Expand initial_solution to a new dimension at position 1 (for T)
+    # |batch_size| x |1| x |O|
+    initial_expanded = initial_solution.unsqueeze(1).expand(-1, T, -1)
 
-    # Step 2: Reshape valid_solution to (batch_size, T, 1) for concatenation
-    valid_reshaped = valid_solution.unsqueeze(2)  # Shape: (batch_size, T, 1)
+    # Reshape valid_solution to (batch_size, T, 1) for concatenation
+    # |batch_size| x |T| x |1|
+    valid_reshaped = valid_solution.unsqueeze(2)
 
-    # Step 3: Concatenate along the last dimension to get (batch_size, T, O + 1)
-    all_solutions = torch.cat([initial_expanded, valid_reshaped], dim=2)  # Shape: (batch_size, T, O + 1)
+    # Concatenate along the last dimension to get (batch_size, T, O + 1)
+    # |batch_size| x |T| x |O + 1|
+    all_solutions = torch.cat([initial_expanded, valid_reshaped], dim=2)
 
     return all_solutions
 
@@ -125,11 +172,7 @@ def _next_order_greedy(covmats: torch.Tensor,
 
     # Initial valid candidates to iterate one by one
     # |batch_size| x |N-order|
-    all_elements = torch.arange(N, device=device)
-    valid_candidates = torch.stack([
-        all_elements[~torch.isin(all_elements, initial_solution[b])]
-        for b in torch.arange(batch_size, device=device)
-    ]).contiguous()
+    valid_candidates = get_valid_candidates(initial_solution, N, device)
     
     # |batch_size| x |N-order| x |order+1|
     all_solutions = create_all_solutions(initial_solution, valid_candidates)

--- a/thoi/heuristics/greedy.py
+++ b/thoi/heuristics/greedy.py
@@ -7,6 +7,7 @@ from functools import partial
 
 from thoi.measures.gaussian_copula import multi_order_measures
 from thoi.collectors import batch_to_tensor, concat_batched_tensors
+from thoi.heuristics.commons import _get_valid_candidates
 from thoi.heuristics.scoring import _evaluate_nplets
 from thoi.commons import _normalize_input_data
 
@@ -67,53 +68,6 @@ def greedy(X: Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tenso
         current_solution = torch.cat((current_solution, best_candidate.unsqueeze(1)) , dim=1)
     
     return current_solution, torch.stack(best_scores).T
-
-
-def _get_valid_candidates(initial_solution: torch.Tensor, N: int, device: torch.device) -> torch.Tensor:
-    """
-    Efficiently generates valid candidates by excluding elements present in the initial solution.
-
-    Parameters:
-    - initial_solution (torch.Tensor): Tensor of shape (batch_size, o) containing selected indices. Note: o < N and all elements must be unique.
-    - N (int): Total number of possible elements.
-    - device (torch.device): Device where tensors are located.
-
-    Returns:
-    - valid_candidates (torch.Tensor): Tensor of shape (batch_size, N - o) containing valid candidate indices.
-    """
-    
-    batch_size, o = initial_solution.shape
-
-    # Create a tensor of all elements, expanded across the batch
-    # |batch_size| x |N|
-    all_elements = torch.arange(N, device=device).unsqueeze(0).expand(batch_size, N)
-
-    # Expand initial_solution for comparison
-    # |batch_size| x |1| x |o|
-    initial_solution_expanded = initial_solution.unsqueeze(1)
-
-    # Expand all_elements for comparison
-    # |batch_size| x |N| x |1|
-    all_elements_expanded = all_elements.unsqueeze(2)
-
-    # Compare all_elements with initial_solution
-    # This creates a mask where True indicates the element is in initial_solution
-    # |batch_size| x |N| x |o|
-    is_in = (all_elements_expanded == initial_solution_expanded)
-
-    # Determine if any of the o elements match for each (batch, N)
-    # |batch_size| x |N|
-    is_in_any = is_in.any(dim=2)
-
-    # Create a mask for valid candidates (not in initial_solution)
-    # |batch_size| x |N|
-    valid_mask = ~is_in_any
-
-    # Select valid candidates using the mask
-    # |batch_size| x |N - o|
-    valid_candidates = torch.masked_select(all_elements, valid_mask).view(batch_size, N - o)
-
-    return valid_candidates
 
 
 def _create_all_solutions(initial_solution: torch.Tensor, valid_candidates: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
This PR implements improvements to the heuristic algorithms:

* In the greedy algorithm, instead of looping over the valid candidates to create new solution and test them, now we create a single tensor with all posible new solutions, then we batch test them and batch filter the best ones.
* In the simulated annealing we avoid cloning the current solution at every iteration and we use slicing indexing to avoid intermediate tensors creation
* In both algorithm, now we created a more efficient function to create the tensor of valid candidate without python loops using all tensor optimized operations.

This PR implements issue https://github.com/Laouen/THOI/issues/9