### PR TITLE
ci: create GitHub release during publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -40,6 +40,7 @@ jobs:
         git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         git tag $new_version
         git push origin $new_version
+        echo "new_version=$new_version" >> $GITHUB_ENV
     - name: Build package
       run: python -m build
     - name: Publish package
@@ -47,3 +48,13 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Create GitHub Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.new_version }}
+        release_name: ${{ env.new_version }}
+        body: Release ${{ env.new_version }}
+        draft: false
+        prerelease: false


### PR DESCRIPTION
## Summary
- create GitHub release after publishing to PyPI
- export computed version to later steps

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3d6ea8d30832599ebc4045f839f39