### PR TITLE
Add GitHub Pages workflow, docs deps, and update CI action versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,69 @@
+name: Build and deploy documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - README.md
+      - LICENSE
+      - source/**
+      - requirements-docs.txt
+      - thoi/**
+      - requirements.txt
+      - setup.py
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+          cache: pip
+
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements-docs.txt
+
+      - name: Build Sphinx documentation
+        run: |
+          sphinx-build -b html source _site
+          touch _site/.nojekyll
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,11 +11,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+_site/
 
 # PyBuilder
 .pybuilder/

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+sphinx
+myst-parser
+sphinx-rtd-theme
+linkify-it-py


### PR DESCRIPTION
### Motivation
- Provide automated Sphinx documentation build and deployment to GitHub Pages and include required doc dependencies.
- Modernize CI by updating `actions/checkout` and `actions/setup-python` to newer stable releases.
- Ensure the generated site is ignored by Git via `.gitignore` to avoid checking built artifacts into the repo.

### Description
- Added a new workflow `/.github/workflows/pages.yml` that installs docs dependencies, builds Sphinx docs with `sphinx-build -b html source _site`, and deploys the site using the Pages actions.
- Added `requirements-docs.txt` with `sphinx`, `myst-parser`, `sphinx-rtd-theme`, and `linkify-it-py` for documentation builds.
- Updated `/.github/workflows/python-publish.yml` to use `actions/checkout@v6` and `actions/setup-python@v6` while keeping the package test/build and tagging steps.
- Updated `/.github/workflows/tests.yml` to use `actions/checkout@v6` and `actions/setup-python@v6` and added `_site/` to `.gitignore` to exclude built docs.

### Testing
- The workflows are configured to run `pytest tests` as part of the CI in `tests.yml` and in the publish job in `python-publish.yml`.
- No automated CI run was produced for this change in the current PR, so no test results are available from this submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e7e68f608325ba6562362b32937b)